### PR TITLE
fix: Fix third-party calling path

### DIFF
--- a/supermonkey.go
+++ b/supermonkey.go
@@ -47,7 +47,8 @@ func UnpatchAll() {
 }
 
 func init() {
-	content, _ := nm.Parse(os.Args[0])
+	path, _ := os.Executable()
+	content, _ := nm.Parse(path)
 
 	lines := strings.Split(content, "\n")
 	for _, line := range lines {


### PR DESCRIPTION
When the file is in the system `$PATH` directory, such as /bin/test
if you execute the command `test`, an error message will appear.


> 1. the function is inlined, please add //go:noinline to function comment or add -l to gcflags
> 2. your input for symbolName or pkg/obj/method is wrong ...............